### PR TITLE
Always use replace instead of advance

### DIFF
--- a/app/assets/javascripts/turboboost/turboboost.js.coffee
+++ b/app/assets/javascripts/turboboost/turboboost.js.coffee
@@ -57,7 +57,7 @@ turboboostComplete = (e, resp) ->
     if (location = resp.getResponseHeader('Location')) and !$el.attr('data-no-turboboost-redirect')
       e.preventDefault()
       e.stopPropagation()
-      Turbolinks.visit(location)
+      Turbolinks.visit(location, action: 'replace')
       return
     else
       enableForm $el if isForm and Turboboost.handleFormDisabling


### PR DESCRIPTION
Using 'replace' instead of the default (which implicitly is 'advance') does not seem to impact anything functionally on the web side. And in the case of updates/creates, a 'replace' generally makes more sense in turbolinks-ios and turbolinks-android. We could also make it configurable, but it doesn't seem useful or necessary atm.