### PR TITLE
Allow requiring application to determine what files to include

### DIFF
--- a/app/assets/javascripts/turboboost.js.coffee
+++ b/app/assets/javascripts/turboboost.js.coffee
@@ -1,7 +1,3 @@
-#= require jquery
-#= require jquery_ujs
-#= require turbolinks
-
 @Turboboost =
   insertErrors: false
   defaultError: "Sorry, there was an error."


### PR DESCRIPTION
* In a later version of turboboost these are all pulled out, but the version we're on still has them

* We need to load jquery in a different way, so this is causing multiple versions to be included in the app